### PR TITLE
feat: [DEV-338] remove unnecessary dependency on sidekiq

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     workflows_api_client (2.0.2)
       rails (> 5)
-      sidekiq (< 7)
 
 GEM
   remote: https://rubygems.org/
@@ -92,7 +91,6 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -199,7 +197,6 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    redis (4.8.1)
     reek (6.1.4)
       kwalify (~> 0.7.0)
       parser (~> 3.2.0)
@@ -259,10 +256,6 @@ GEM
     sexp_processor (4.17.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    sidekiq (6.5.9)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/workflows_api_client/engine.rb
+++ b/lib/workflows_api_client/engine.rb
@@ -1,5 +1,4 @@
 require 'rails'
-require 'sidekiq'
 
 module WorkflowsApiClient
   class Engine < ::Rails::Engine

--- a/workflows_api_client.gemspec
+++ b/workflows_api_client.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |spec|
   # Rails
   spec.add_dependency 'rails', '> 5'
 
-  # Sidekiq
-  spec.add_dependency 'sidekiq', '< 7'
-
   # Awesome Print is a Ruby library that pretty prints Ruby objects in full color exposing their
   # internal structure with proper indentation
   spec.add_development_dependency 'awesome_print'


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/DEV-338

## Summary

Con la actualización de dependencias que se hizo en UGO se detecto una incompatibilidad con esta gema por la dependencia compartida `Sidekiq`. Se analizo y se detecto que no es necesario tener `Sidekiq` en esta librería, quedo de un primer enfoque cuando comencé a crear la gema pero al final no fue necesario. Se elimino la dependencia y se probo en UGO localmente.

Para las pruebas se implemento localmente en UGO la gema y se hicieron pruebas con el servicio `index` de `Workflows` apuntando al entorno DEV de la API.

## Screenshots

### Respuesta 202 de UGO
![Captura de pantalla de 2023-11-15 15-59-27](https://github.com/widergy/Workflows-API-Client/assets/92753204/d38cd74f-f33c-410f-b0e1-a1d46b432043)

### Job Response
![Captura de pantalla de 2023-11-15 15-59-37](https://github.com/widergy/Workflows-API-Client/assets/92753204/8220258f-3af5-4511-8411-bf953b69d53f)

### Request a Workflows
![Captura de pantalla de 2023-11-15 15-59-16](https://github.com/widergy/Workflows-API-Client/assets/92753204/060e1de6-7e17-44a4-9d1c-e3baad57fbe4)

### Método de la gema `WorkflowsApiClient`
![Captura de pantalla de 2023-11-15 15-54-54](https://github.com/widergy/Workflows-API-Client/assets/92753204/48e8c86b-30f9-4355-9f00-360a102350be)

### Tests y Rubocop
![Captura de pantalla de 2023-11-16 09-30-01](https://github.com/widergy/Workflows-API-Client/assets/92753204/6ae1d8e1-81fb-4f51-bc43-b08de93e744c)

## Checklist 

- [x] Verifiqué / Realicé los cambios requeridos en Active Admin, o alguna configuración adicional (en caso de corresponder) ⚙️
- [x] Verifiqué si mis cambios requieren actualizar la documentación técnica y la actualicé (en caso de corresponder). 📝
- [x] Revisé los archivos modificados antes de liberar el pull request para revisión. 👩🏻‍💻
- [x] Actualicé la card de JIRA considerando: **estado**, **horas incurridas**, **enfoque tomado como comentario de la card** y **requisitos de configuración asociados**✅
- [x] El título de mi PR sigue la convención requerida 👉 [%scope - %descripcion](https://www.conventionalcommits.org/en/v1.0.0/)

- [ ] **Post Merge** 👉 Actualicé el status de la card en JIRA.
