### PR TITLE
docs: Bump version, update changelog and Gemfile.lock for Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file, in reverse 
 * `Y` (MINOR) is bumped when we add new features. Occasionally a `Y` release may include small breaking changes. Those will be notified via CHANGELOG entries and/or deprecation notices if there are breaking changes.
 * `X` (MAJOR) is incremented for significant breaking changes. This is reserved for special occasions, like when an API version is deprecated.
 
+## [`0.1.0`] (2023-11-22)
+
+### Breaking changes:
+* None
+
+### Fixes:
+* None
+
+### Minor enhancements / New features:
+* [#26](https://github.com/widergy/Workflows-API-Client/pull/26): feat: [DEV-338] remove unnecessary dependency on sidekiq
+
 ## [`2.0.2`] (2023-07-11)
 
 ### Breaking changes:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    workflows_api_client (2.0.2)
+    workflows_api_client (0.1.0)
       rails (> 5)
 
 GEM

--- a/lib/workflows_api_client/version.rb
+++ b/lib/workflows_api_client/version.rb
@@ -1,3 +1,3 @@
 module WorkflowsApiClient
-  VERSION = '2.0.2'.freeze
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
## Summary

Actualizar versión, changelog y Gemfile.lock en preparación de la Release v0.3.0 #29 

Se decidió volver a una versión de desarrollo para representar el estado actual de esta librería correctamente.

## JIRA Card

https://widergy.atlassian.net/browse/DEV-338
